### PR TITLE
I18n not loading translations

### DIFF
--- a/lib/redmine/i18n.rb
+++ b/lib/redmine/i18n.rb
@@ -148,7 +148,7 @@ module Redmine
 
         def init_translations(locale)
           locale = locale.to_s
-          paths = ::I18n.load_path.select {|path| File.basename(path, '.*') == locale}
+          paths = ::I18n.load_path.select {|path| File.basename(path, '.*') == locale.to_s}
           load_translations(paths)
           translations[locale] ||= {}
         end


### PR DESCRIPTION
Redmine wasn't able to find pt-BR translations, debugging the code I found out that init_translations was comparing "locale", which was a symbol, to a string containing the file name. This way the translation file was never loaded, so I just put a conversion to string before the comparison.
- Ruby 1.8.7
- Windows Server 2008
