### PR TITLE
Improvements to migrate_from_trac rake task

### DIFF
--- a/lib/tasks/migrate_from_trac.rake
+++ b/lib/tasks/migrate_from_trac.rake
@@ -762,9 +762,11 @@ namespace :redmine do
     puts
 
     # Turn off email notifications
+    old_notified_events = Settings.notified_events
     Setting.notified_events = []
 
     TracMigrate.migrate
+    Setting.notified_events = old_notified_events
   end
 end
 


### PR DESCRIPTION
I must be the only person still regularly importing legacy projects from trac, but there have been a few issues with this rake task for a while. I'd fixed them locally and would like to see them upstream.

Thanks,

Brandon
