### PR TITLE
Changed extra_info from text to longtext field type

### DIFF
--- a/db/migrate/20110511000000_add_repositories_extra_info.rb
+++ b/db/migrate/20110511000000_add_repositories_extra_info.rb
@@ -1,6 +1,6 @@
 class AddRepositoriesExtraInfo < ActiveRecord::Migration
   def self.up
-    add_column :repositories, :extra_info, :text
+    add_column :repositories, :extra_info, :text, :limit => 4294967295
   end
 
   def self.down


### PR DESCRIPTION
Ran into an issue where we hit the 65535 limit of the text field, and that prevented repo refresh in redmine.
