### PR TITLE
Retrieve automatically changes when sys/fetch_changesets is called

### DIFF
--- a/app/controllers/sys_controller.rb
+++ b/app/controllers/sys_controller.rb
@@ -60,6 +60,7 @@ class SysController < ActionController::Base
     end
     projects.each do |project|
       project.repositories.each do |repository|
+        repository.fetch_all if repository.scm_adapter == Redmine::Scm::Adapters::GitAdapter
         repository.fetch_changesets
       end
     end

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -154,6 +154,10 @@ class Repository::Git < Repository
     save_revisions(prev_db_heads, repo_heads)
   end
 
+  def fetch_all
+    scm.fetch_all
+  end
+
   def save_revisions(prev_db_heads, repo_heads)
     h = {}
     opts = {}

--- a/lib/redmine/scm/adapters/git_adapter.rb
+++ b/lib/redmine/scm/adapters/git_adapter.rb
@@ -97,6 +97,11 @@ module Redmine
           nil
         end
 
+        def fetch_all
+          logger.info "Fetching git changes"
+          git_cmd(%w|fetch --all|) {|io| puts io.readlines}
+        end
+
         def tags
           return @tags if @tags
           cmd_args = %w|tag|


### PR DESCRIPTION
# How to configure redmine to automatically fetch changes?

You have to do the following settings in github.com and in the redmine app.
**For github.com:**
- go to github.com repo settings. And put the Redmine API key generated as Redmine service hook.
  Put valid project id.
- Check all options in github
  *\* Fetch Commits
  *\* Update Redmine Issues About Commits
  *\* Active

**For redmine:**
- go to Administration > Settings > Repositories, Generate key and add it to github.com
- Add valid ssh key with no password to the passenger user which runs redmine. Usually this is apache or www-data. (Use PassengerDefaultUser setting in the apache config to set the rails user in passenger).
- Add the ssh key to the profile in github which will retrieve the changes
