### PR TITLE
Correct commit syntax when updating issue through repo commit (#14405)

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -152,12 +152,15 @@ class Changeset < ActiveRecord::Base
 
   def text_tag(ref_project=nil)
     tag = if scmid?
-      "commit:#{scmid}"
+      "#{scmid}"
     else
       "r#{revision}"
     end
     if repository && repository.identifier.present?
       tag = "#{repository.identifier}|#{tag}"
+    end
+    if scmid?
+      tag = "commit:#{tag}"
     end
     if ref_project && project && ref_project != project
       tag = "#{project.identifier}:#{tag}"


### PR DESCRIPTION
The repo identifier must be between the 'commit:' and the hash for Redmine to parse correctly, e.g. 'commit:repo|abcd'. When using SVN however, the 'r' is always in front of the revision number, and the repo ID is prepended, e.g. 'repo:r1234'.
