### PR TITLE
mailer.rb: Fix message-id generation for outgoing emails.

### DIFF
--- a/app/models/mailer.rb
+++ b/app/models/mailer.rb
@@ -458,7 +458,7 @@ class Mailer < ActionMailer::Base
     if rand
       hash << Redmine::Utils.random_hex(8)
     end
-    host = Setting.mail_from.to_s.gsub(%r{^.*@}, '')
+    host = Setting.mail_from.to_s.gsub(%r{^.*@}, '').gsub(%r{>}, '')
     host = "#{::Socket.gethostname}.redmine" if host.empty?
     "#{hash.join('.')}@#{host}"
   end


### PR DESCRIPTION
Without this fix, if one configures Redmine to use something like `Redmine <redmine@example.com>` as the outgoing address (which works nicely, exept for the message-id), the message-id is set to invalid string like `<redmine.journal-numbers@example.com>>` becase of the invalid hostname extraction, which returns `example.com>` as the host.
This results in Google ignoring the invalid message-id field and replacing it with an autogenerated one. The message then fails DKIM check and goes into the spam folder.

This commit fixes invalid message-id generation, and everything works fine for me now.
