### PR TITLE
Simplified Chinese translation updated 

### DIFF
--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1090,7 +1090,7 @@ zh:
   field_inherit_members: 继承父项目成员
   field_closed_on: 结束日期
   field_generate_password: 生成密码
-  setting_default_projects_tracker_ids: 新项目的默认跟踪标签
+  setting_default_projects_tracker_ids: 新建项目默认跟踪标签
   label_total_time: 合计
   notice_account_not_activated_yet: 您的账号尚未激活. 若您要重新收取激活邮件, 请<a href="%{url}">单击此链接</a>.
   notice_account_locked: 您的帐号已被锁定


### PR DESCRIPTION
I noticed that the Chinese translation is not completed when I deployed my redmine 2.3.3 server in my company, So I did the following translation which work fine in my production server.
