### PR TITLE
fixed member deletion to avoid dublicate after_destroy callbacks

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -96,7 +96,7 @@ class MembersController < ApplicationController
 
   def destroy
     if request.delete? && @member.deletable?
-      @member.destroy
+      @member.roles.destroy_all
     end
     respond_to do |format|
       format.html { redirect_to_settings_in_projects }


### PR DESCRIPTION
The callback 'after_destroy' for Member is called twice when deleting a member due to the following lines
https://github.com/redmine/redmine/blob/master/app/controllers/members_controller.rb:99
and
https://github.com/redmine/redmine/blob/master/app/models/member_role.rb:42
