### PR TITLE
Added proper HTML scrubbing to Markdown renderer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ platforms :mri, :mingw do
   group :markdown do
     # TODO: upgrade to redcarpet 3.x when ruby1.8 support is dropped
     gem "redcarpet", "~> 2.3.0"
+    gem "loofah", "~> 1.2.0"
   end
 end
 

--- a/lib/redmine/wiki_formatting/markdown/formatter.rb
+++ b/lib/redmine/wiki_formatting/markdown/formatter.rb
@@ -16,6 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 require 'cgi'
+require 'loofah'
 
 module Redmine
   module WikiFormatting
@@ -57,7 +58,8 @@ module Redmine
           html.gsub!(/(\w):&quot;(.+?)&quot;/) do
             "#{$1}:\"#{$2}\""
           end
-          html
+          # return scrubbed HTML
+          Loofah.fragment(html).scrub!(:strip).to_s
         end
 
         def get_section(index)
@@ -119,7 +121,6 @@ module Redmine
         def formatter
           @@formatter ||= Redcarpet::Markdown.new(
             Redmine::WikiFormatting::Markdown::HTML.new(
-              :filter_html => true,
               :hard_wrap => true
             ),
             :autolink => true,

--- a/test/unit/lib/redmine/wiki_formatting/markdown_formatter.rb
+++ b/test/unit/lib/redmine/wiki_formatting/markdown_formatter.rb
@@ -60,5 +60,10 @@ STR
     assert_equal '<p>This is a <a href="/issues">link</a></p>', @formatter.new(text).to_html.strip
   end
 
+  def test_html_is_safe
+    text = '<script>alert(1)</script> <b onclick="alert(1)">clickable</b> [bad link](javascript:alert(1\\))'
+    assert_equal '<p>alert(1) <b>clickable</b> <a class="external">bad link</a></p>', @formatter.new(text).to_html.strip
+  end
+
   end
 end


### PR DESCRIPTION
The current renderer strips HTML (contrary to conventional Markdown) and still fails to catch everything:

``` markdown
[bad link](javascript:alert(1\))
```

This fixes both behaviours. See also [scrub-classes] for a patch to remove unrecognized classes that could potentially be used to annoy; I haven’t included it here (nor completed the list) because the existing implementation already allows all classes through syntax highlighting:

<pre lang="markdown"><code>~~~any-class-here
code block
~~~</code></pre>


[scrub-classes]: https://github.com/charmander/redmine/tree/scrub-classes
