### PR TITLE
Explicitly handle .js files as text so that JS attachment can be previewed.

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -213,8 +213,11 @@ class Attachment < ActiveRecord::Base
     end
   end
 
+  EXPLICIT_TEXT_EXT_LIST = %w(.js)
+
   def is_text?
-    Redmine::MimeType.is_type?('text', filename)
+    EXPLICIT_TEXT_EXT_LIST.include?(File.extname(filename).downcase) ||
+      Redmine::MimeType.is_type?('text', filename)
   end
 
   def is_diff?


### PR DESCRIPTION
Currently JavaScript attachment is not recognized as text, so it cannot be previewed.
Though it's mime type is application/javascript, it actually is text.
I think it's natural to handle it as text file to preview it.
