### PR TITLE
fix internal server error with no title link(e.g. [](name))

### DIFF
--- a/lib/redmine/wiki_formatting/markdown/formatter.rb
+++ b/lib/redmine/wiki_formatting/markdown/formatter.rb
@@ -28,7 +28,7 @@ module Redmine
           unless link && link.starts_with?('/')
             css = 'external'
           end
-          content_tag('a', content.html_safe, :href => link, :title => title, :class => css)
+          content_tag('a', (content || "").html_safe, :href => link, :title => title, :class => css)
         end
 
         def block_code(code, language)


### PR DESCRIPTION
Fix internal server error if no title link specified in markdown format. Show only link mark after applying this PR.
