### PR TITLE
Getting ready for Teatro.io cloud stage server

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -1,0 +1,12 @@
+stage:
+  before:
+    - cp config/configuration.yml.example config/configuration.yml
+    - cp config/database.teatro.yml config/database.yml
+    - mkdir -p tmp tmp/pdf public/plugin_assets
+    - chmod -R 755 files log tmp public/plugin_assets
+    - export REDMINE_LANG=en
+
+  database:
+    - bundle exec rake generate_secret_token db:create db:migrate
+    - bundle exec rake redmine:load_default_data
+    - bundle exec rake db:seed

--- a/Gemfile
+++ b/Gemfile
@@ -105,3 +105,5 @@ Dir.glob File.expand_path("../plugins/*/Gemfile", __FILE__) do |file|
   #TODO: switch to "eval_gemfile file" when bundler >= 1.2.0 will be required (rails 4)
   instance_eval File.read(file), file
 end
+
+gem "thin"

--- a/config/database.teatro.yml
+++ b/config/database.teatro.yml
@@ -1,0 +1,13 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  database: teatro
+  pool: 5
+  min_messages: warning
+  username: postgres
+
+development:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -1,0 +1,1 @@
+Rails.application.config.logger = Logger.new(STDOUT)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,42 @@
+puts "Seeding..."
+ActiveRecord::Base.transaction do
+  user = User.last
+
+  project = Project.create!(
+    name: "Teatro",
+    description: "Cloud staging server",
+    homepage: "http://teatro.io",
+    is_public: true,
+    identifier: "teatro",
+    status: 1
+  )
+
+  issue = Issue.create!(
+    tracker_id: 1,
+    project_id: project.id,
+    subject: "Something went wrong",
+    description: "We don't know what",
+    due_date: nil,
+    category_id: nil,
+    status_id: 1,
+    assigned_to_id: nil,
+    priority_id: 2,
+    author_id: user.id,
+    start_date: 1.day.ago,
+    done_ratio: 0,
+    estimated_hours: nil,
+    root_id: 1,
+    is_private: false,
+    closed_on: nil
+  )
+
+  news = News.create!(
+    project_id: project.id,
+    title: "We got fresh cookies!",
+    summary: "Super tasty",
+    description: "With chocolate bars",
+    author_id: user.id
+  )
+
+  puts "Seeding done"
+end


### PR DESCRIPTION
Hey!

I am developer at Teatro.io and I want to offer you our service — it automatically creates a staging server for each opened pull request.

Teatro.io is free for open source projects — some large projects like GitLab (https://github.com/gitlabhq/gitlabhq/pull/7140 ) and ErrBit (works out-of-the-box, @ndbroadbent approved Teatro) are already using Teatro as free stage servers.

Here's URL of Teatro stage server for my fork of Redmine: http://master.228a0487b92a1a4fbc91b9a666240cae.ttrcloud.com/

When you connect project to Teatro, we'll automatically post a comment (via @TeatroIO) with like to unique stage server that was made for this specific branch.

To use Teatro you need:
— send me your email (as in Github settings; you have to be owner/admin of this repo), I'll send you invitation
— then, sign in using Github account on http://Teatro.io
— add your project

Have any questions? Just drop me line — teatro@semenyukdmitriy.com.
