### PR TITLE
spent_hours are expected to be reloaded as well, aren't they?

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -195,6 +195,7 @@ class Issue < ActiveRecord::Base
     @workflow_rule_by_attribute = nil
     @assignable_versions = nil
     @relations = nil
+    @spent_hours = nil
     base_reload(*args)
   end
 


### PR DESCRIPTION
In my opinion this should be done on reload. Cache forgotten.
