### PR TITLE
Mantis migration fix

### DIFF
--- a/lib/tasks/migrate_from_mantis.rake
+++ b/lib/tasks/migrate_from_mantis.rake
@@ -1,4 +1,4 @@
-edmine - project management software
+# Redmine - project management software
 # Copyright (C) 2006-2014  Jean-Philippe Lang
 #
 # This program is free software; you can redistribute it and/or


### PR DESCRIPTION
Updated the rake file that performs the Mantis migration by correctly typing dates 

also removed categories import, which is broken
