### PR TITLE
Fixed for active-record 4.2 because it is no longer support #type_cast.

### DIFF
--- a/lib/plugins/acts_as_versioned/lib/acts_as_versioned.rb
+++ b/lib/plugins/acts_as_versioned/lib/acts_as_versioned.rb
@@ -447,7 +447,7 @@ module ActiveRecord #:nodoc:
 
           def write_changed_attribute(attr_name, attr_value)
             # Convert to db type for comparison. Avoids failing Float<=>String comparisons.
-            attr_value_for_db = self.class.columns_hash[attr_name.to_s].type_cast(attr_value)
+            attr_value_for_db = self.class.columns_hash[attr_name.to_s].type_cast_from_database(attr_value)
             (self.altered_attributes ||= []) << attr_name.to_s unless self.changed?(attr_name) || self.send(attr_name) == attr_value_for_db
             write_attribute(attr_name, attr_value_for_db)
           end


### PR DESCRIPTION
I try update plugins for redmine-3.0.0.
I noticed exceptions when plugin use acts_as_versioned because of ActiveRecord.
Please check this pull request.

Best Regards,