### PR TITLE
Shows admin tables in grids

### DIFF
--- a/app/views/roles/permissions.html.erb
+++ b/app/views/roles/permissions.html.erb
@@ -2,54 +2,69 @@
 
 <%= form_tag(permissions_roles_path, :id => 'permissions_form') do %>
 <%= hidden_field_tag 'permissions[0]', '', :id => nil %>
-<div class="autoscroll">
-<table class="list permissions">
-<thead>
-    <tr>
-    <th><%=l(:label_permissions)%></th>
+
+<%= stylesheet_link_tag 'divgrid' %>
+<%= javascript_include_tag 'divgrid' %>
+
+<div style="position: relative; overflow: hidden; white-space: nowrap; border-width: 1px; border-style: solid; border-color: #CCC;">
+  <!-- Cell 0 -->
+  <div id="g_bl" style="position: absolute; z-index: 2;">
+    <div class="g_c g_h">&nbsp;</div>
+  </div>
+  <!-- Line 0  -->
+  <div id="g_fl" style="position: absolute; left: 0px; right: 13px; overflow: hidden; z-index: 1;">
+      <div style="display: inline-block; margin-right: -4px;">
+        <div class="g_c g_h">&nbsp;</div>
+      </div>
+      <% @roles.each do |role| %>
+        <div style="display: inline-block; margin-right: -4px;">
+          <div class="g_c g_h">
+            <%= content_tag(role.builtin? ? 'em' : 'span', role.name) %>
+          </div>
+        </div>
+      <% end %>
+  </div>
+  <!-- Row 0 -->
+  <div id="g_fr" style="position: absolute; left: 0px; top: 0px; bottom: 13px; overflow: hidden; z-index: 1;">
+    <% perms_by_module = @permissions.group_by {|p| p.project_module.to_s} %>
+    <% even = true %>
+    <% perms_by_module.keys.sort.each do |mod| %>
+      <div class="g_c g_v g_s<%= (even)? " g_e":" g_o" %>">
+        <%= l_or_humanize(mod, :prefix => 'project_module_') %>
+      </div>
+      <% even = !even %>
+      <% perms_by_module[mod].each do |permission| %>
+        <div class="g_c g_v<%= (even)? " g_e":" g_o" %>">
+          <% even = !even %>
+          <%= l_or_humanize(permission.name, :prefix => 'permission_') %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+  <!-- Body -->
+  <div id="g_bd" style="width: 100%; max-height: 80vh; overflow: scroll;" onscroll="g_scroll(this, 'g_fl', 'g_fr')">
+    <div style="display: inline-block; margin-right: -4px;"></div>
     <% @roles.each do |role| %>
-    <th>
-        <%= content_tag(role.builtin? ? 'em' : 'span', role.name) %>
-        <%= link_to_function(image_tag('toggle_check.png'), "toggleCheckboxesBySelector('input.role-#{role.id}')",
-                                                            :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}") %>
-    </th>
-    <% end %>
-    </tr>
-</thead>
-<tbody>
-<% perms_by_module = @permissions.group_by {|p| p.project_module.to_s} %>
-<% perms_by_module.keys.sort.each do |mod| %>
-    <% unless mod.blank? %>
-        <tr class="group open">
-          <td>
-            <span class="expander" onclick="toggleRowGroup(this);">&nbsp;</span>
-            <%= l_or_humanize(mod, :prefix => 'project_module_') %>
-          </td>
-          <% @roles.each do |role| %>
-          <td class="role"><%= role.name %></td>
+      <div style="display: inline-block; margin-right: -4px;">
+        <% even = true %>
+        <% perms_by_module.keys.sort.each do |mod| %>
+          <div class="g_c<%= " g_s" unless role == @roles.last %><%= (even)? " g_e":" g_o" %>"></div>
+          <% even = !even %>
+          <% perms_by_module[mod].each do |permission| %>
+            <div class="g_c<%= (even)? " g_e":" g_o" %>" title="<%= "#{l_or_humanize(permission.name, :prefix => 'permission_')} - #{role.name}" %>">
+              <% even = !even %>
+              <% if role.setable_permissions.include? permission %>
+                  <%= check_box_tag "permissions[#{role.id}][]", permission.name, (role.permissions.include? permission.name), :id => nil, :class => "role-#{role.id}" %>
+              <% end %>
+            </div>
           <% end %>
-        </tr>
+      </div>
     <% end %>
-    <% perms_by_module[mod].each do |permission| %>
-        <tr class="<%= cycle('odd', 'even') %> permission-<%= permission.name %>">
-        <td class="name">
-            <%= link_to_function(image_tag('toggle_check.png'), "toggleCheckboxesBySelector('.permission-#{permission.name} input')",
-                                                                :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}") %>
-            <%= l_or_humanize(permission.name, :prefix => 'permission_') %>
-        </td>
-        <% @roles.each do |role| %>
-        <td>
-        <% if role.setable_permissions.include? permission %>
-          <%= check_box_tag "permissions[#{role.id}][]", permission.name, (role.permissions.include? permission.name), :id => nil, :class => "role-#{role.id}" %>
-        <% end %>
-        </td>
-        <% end %>
-        </tr>
-    <% end %>
-<% end %>
-</tbody>
-</table>
+  </div>
 </div>
+
+<script> g_adjust('g_bl', 'g_fr', 'g_fl', 'g_bd'); </script>
+
 <p><%= check_all_links 'permissions_form' %></p>
 <p><%= submit_tag l(:button_save) %></p>
 <% end %>

--- a/app/views/trackers/fields.html.erb
+++ b/app/views/trackers/fields.html.erb
@@ -2,67 +2,84 @@
 
 <% if @trackers.any? %>
   <%= form_tag fields_trackers_path do %>
-    <div class="autoscroll">
-    <table class="list">
-    <thead>
-      <tr>
-        <th></th>
+    <%= stylesheet_link_tag 'divgrid' %>
+    <%= javascript_include_tag 'divgrid' %>
+
+    <div style="position: relative; overflow: hidden; white-space: nowrap; border-width: 1px; border-style: solid; border-color: #CCC;">
+      <!-- Cell 0 -->
+      <div id="g_bl" style="position: absolute; z-index: 2;">
+        <div class="g_c g_h">&nbsp;</div>
+      </div>
+      <!-- Line 0  -->
+      <div id="g_fl" style="position: absolute; left: 0px; right: 13px; overflow: hidden; z-index: 1;">
+        <div style="display: inline-block; margin-right: -4px;">
+          <div class="g_c g_h">&nbsp;</div>
+        </div>
         <% @trackers.each do |tracker| %>
-        <th>
-          <%= tracker.name %>
-          <%= link_to_function(image_tag('toggle_check.png'), "toggleCheckboxesBySelector('input.tracker-#{tracker.id}')",
-                                                              :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}") %>
-        </th>
+          <div style="display: inline-block; margin-right: -4px;">
+            <div class="g_c g_h">
+              <%= tracker.name %>
+            </div>
+          </div>
         <% end %>
-      </tr>
-    </thead>
-    <tbody>
-      <tr class="group open">
-        <td colspan="<%= @trackers.size + 1 %>">
-          <span class="expander" onclick="toggleRowGroup(this);">&nbsp;</span>
+      </div>
+      <!-- Row 0 -->
+      <div id="g_fr" style="position: absolute; left: 0px; top: 0px; bottom: 13px; overflow: hidden; z-index: 1;">
+        <div class="g_c">&nbsp;</div>
+        <% even = false %>
+        <div class="g_c g_v g_s<%= (even)? " g_e":" g_o" %>">
+          <% even = !even %>
           <%= l(:field_core_fields) %>
-        </td>
-      </tr>
-      <% Tracker::CORE_FIELDS.each do |field| %>
-      <tr class="<%= cycle("odd", "even") %>">
-        <td class="name">
-          <%= link_to_function(image_tag('toggle_check.png'), "toggleCheckboxesBySelector('input.core-field-#{field}')",
-                                                              :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}") %>
-          <%= l("field_#{field}".sub(/_id$/, '')) %>
-        </td>
-        <% @trackers.each do |tracker| %>
-        <td>
-          <%= check_box_tag "trackers[#{tracker.id}][core_fields][]", field, tracker.core_fields.include?(field),
-                            :class => "tracker-#{tracker.id} core-field-#{field}", :id => nil %>
-        </td>
+        </div>
+        <% Tracker::CORE_FIELDS.each do |field| %>
+          <div class="g_c g_v<%= (even)? " g_e":" g_o" %>">
+            <% even = !even %>
+            <%= l("field_#{field}".sub(/_id$/, '')) %>
+          </div>
         <% end %>
-      </tr>
-      <% end %>
-      <% if @custom_fields.any? %>
-        <tr class="group open">
-          <td colspan="<%= @trackers.size + 1 %>">
-            <span class="expander" onclick="toggleRowGroup(this);">&nbsp;</span>
+        <% if @custom_fields.any? %>
+          <div class="g_c g_v g_s<%= (even)? " g_e":" g_o" %>">
+            <% even = !even %>
             <%= l(:label_custom_field_plural) %>
-          </td>
-        </tr>
-        <% @custom_fields.each do |field| %>
-        <tr class="<%= cycle("odd", "even") %>">
-          <td class="name">
-            <%= link_to_function(image_tag('toggle_check.png'), "toggleCheckboxesBySelector('input.custom-field-#{field.id}')",
-                                                                :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}") %>
-            <%= field.name %>
-          </td>
-          <% @trackers.each do |tracker| %>
-          <td>
-            <%= check_box_tag "trackers[#{tracker.id}][custom_field_ids][]", field.id, tracker.custom_fields.include?(field),
-                              :class => "tracker-#{tracker.id} custom-field-#{field.id}", :id => nil %>
-          </td>
+          </div>
+          <% @custom_fields.each do |field| %>
+            <div class="g_c g_v<%= (even)? " g_e":" g_o" %>">
+              <% even = !even %>
+              <%= field.name %>
+            </div>
           <% end %>
-        </tr>
         <% end %>
-      <% end %>
-    </tbody>
-    </table>
+      </div>
+      <!-- Body -->
+      <div id="g_bd" style="width: 100%; max-height: 80vh; overflow: scroll;" onscroll="g_scroll(this, 'g_fl', 'g_fr')">
+        <div style="display: inline-block; margin-right: -4px;"></div>
+        <% @trackers.each do |tracker| %>
+          <div style="display: inline-block; margin-right: -4px;">
+            <div class="g_c">&nbsp;</div>
+            <% even = false %>
+            <div class="g_c<%= " g_s" unless tracker == @trackers.last %><%= (even)? " g_e":" g_o" %>"></div>
+            <% even = !even %>
+            <% Tracker::CORE_FIELDS.each do |field| %>
+              <div class="g_c<%= (even)? " g_e":" g_o" %>" title="<%= "#{l("field_#{field}".sub(/_id$/, ''))} - #{tracker}" %>">
+                <% even = !even %>
+                <%= check_box_tag "trackers[#{tracker.id}][core_fields][]", field, tracker.core_fields.include?(field),
+                                  :class => "tracker-#{tracker.id} core-field-#{field}", :id => nil %>
+              </div>
+            <% end %>
+            <% if @custom_fields.any? %>
+              <div class="g_c<%= " g_s" unless tracker == @trackers.last %><%= (even)? " g_e":" g_o" %>"></div>
+              <% even = !even %>
+              <% @custom_fields.each do |field| %>
+                <div class="g_c<%= (even)? " g_e":" g_o" %>" title="<%= "#{field.name} - #{tracker}" %>">
+                  <% even = !even %>
+                  <%= check_box_tag "trackers[#{tracker.id}][custom_field_ids][]", field.id, tracker.custom_fields.include?(field),
+                                    :class => "tracker-#{tracker.id} custom-field-#{field.id}", :id => nil %>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     </div>
     <p><%= submit_tag l(:button_save) %></p>
     <% @trackers.each do |tracker| %>
@@ -70,6 +87,9 @@
       <%= hidden_field_tag "trackers[#{tracker.id}][custom_field_ids][]", '' %>
     <% end %>
   <% end %>
+
+  <script> g_adjust('g_bl', 'g_fr', 'g_fl', 'g_bd'); </script>
+
 <% else %>
   <p class="nodata"><%= l(:label_no_data) %></p>
 <% end %>

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -1,41 +1,47 @@
-<table class="list workflows transitions transitions-<%= name %>">
-<thead>
-  <tr>
-    <th>
-      <%= link_to_function(image_tag('toggle_check.png'), "toggleCheckboxesBySelector('table.transitions-#{name} input')",
-                                                          :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}") %>
-      <%=l(:label_current_status)%>
-    </th>
-    <th colspan="<%= @statuses.length %>"><%=l(:label_new_statuses_allowed)%></th>
-  </tr>
-  <tr>
-    <td></td>
-    <% for new_status in @statuses %>
-    <td style="width:<%= 75 / @statuses.size %>%;">
-      <%= link_to_function(image_tag('toggle_check.png'), "toggleCheckboxesBySelector('table.transitions-#{name} input.new-status-#{new_status.id}')",
-                                                      :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}") %>
-      <%= new_status.name %>
-    </td>
-    <% end %>
-  </tr>
-</thead>
-<tbody>
-  <% for old_status in [nil] + @statuses %>
-  <% next if old_status.nil? && name != 'always' %>
-  <tr class="<%= cycle("odd", "even") %>">
-    <td class="name">
-      <%= link_to_function(image_tag('toggle_check.png'), "toggleCheckboxesBySelector('table.transitions-#{name} input.old-status-#{old_status.try(:id) || 0}')",
-                                                          :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}") %>
-
-      <%= old_status ? old_status.name : content_tag('em', l(:label_issue_new)) %>
-    </td>
-    <% for new_status in @statuses -%>
-    <% checked = workflows.detect {|w| w.old_status == old_status && w.new_status == new_status} %>
-    <td class="<%= checked ? 'enabled' : '' %>">
-      <%= transition_tag workflows, old_status, new_status, name %>
-    </td>
-    <% end -%>
-  </tr>
+<!-- Cell 0 -->
+<div id="g_bl_<%= name %>" style="position: absolute; z-index: 2;">
+  <div class="g_c g_h">&nbsp;</div>
+</div>
+<!-- Line 0  -->
+<div id="g_fl_<%= name %>" style="position: absolute; left: 0px; right: 13px; overflow: hidden; z-index: 1;">
+  <div style="display: inline-block; margin-right: -4px;">
+    <div class="g_c g_h">&nbsp;</div>
+  </div>
+  <% for new_status in @statuses %>
+    <div style="display: inline-block; margin-right: -4px;">
+      <div class="g_c g_h">
+        <%= new_status.name %>
+      </div>
+    </div>
   <% end %>
-</tbody>
-</table>
+</div>
+<!-- Row 0 -->
+<div id="g_fr_<%= name %>" style="position: absolute; left: 0px; top: 0px; bottom: 13px; overflow: hidden; z-index: 1;">
+  <div class="g_c">&nbsp;</div>
+  <% even = false %>
+  <% for old_status in [nil] + @statuses %>
+    <% next if old_status.nil? && name != 'always' %>
+    <div class="g_c g_v<%= (even)? " g_e":" g_o" %>">
+      <% even = !even %>
+      <%= old_status ? old_status.name : content_tag('em', l(:label_issue_new)) %>
+    </div>
+  <% end %>
+</div>
+<!-- Body -->
+<div id="g_bd_<%= name %>" style="width: 100%; max-height: 80vh; overflow: scroll;" onscroll="g_scroll(this, 'g_fl_<%= name %>', 'g_fr_<%= name %>')">
+  <div style="display: inline-block; margin-right: -4px;"></div>
+  <% for new_status in @statuses %>
+    <div style="display: inline-block; margin-right: -4px;">
+      <div class="g_c">&nbsp;</div>
+      <% even = false %>
+      <% for old_status in [nil] + @statuses %>
+        <% next if old_status.nil? && name != 'always' %>
+        <% checked = workflows.detect {|w| w.old_status == old_status && w.new_status == new_status} %>
+        <div class="g_c<%= checked ? " g_m" : (even)? " g_e" : " g_o" %>" title="<%= old_status ? old_status.name : content_tag('em', l(:label_issue_new)) %> &rarr; <%= new_status.name %>">
+          <% even = !even %>
+          <%= transition_tag workflows, old_status, new_status, name %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -32,28 +32,54 @@
 <% end %>
 
 <% if @trackers && @roles && @statuses.any? %>
+  <%= stylesheet_link_tag 'divgrid' %>
+  <%= javascript_include_tag 'divgrid' %>
+
+  <script type="text/javascript">
+    function toggleDivToFieldset(divId, fsClass) {
+      console.log(divId + " " + fsClass);
+      if (fsClass.contains("collapsed")) {
+        document.getElementById(divId).style.visibility='hidden';
+        document.getElementById(divId).style.position='fixed';
+      } else {
+        document.getElementById(divId).style.visibility='';
+        document.getElementById(divId).style.position='relative';
+      }
+    }
+  </script>
+
   <%= form_tag({}, :id => 'workflow_form' ) do %>
     <%= @trackers.map {|tracker| hidden_field_tag 'tracker_id[]', tracker.id, :id => nil}.join.html_safe %>
     <%= @roles.map {|role| hidden_field_tag 'role_id[]', role.id, :id => nil}.join.html_safe %>
     <%= hidden_field_tag 'used_statuses_only', params[:used_statuses_only], :id => nil %>
     <div class="autoscroll">
-      <%= render :partial => 'form', :locals => {:name => 'always', :workflows => @workflows['always']} %>
+      <div id="workflow_always" style="position: relative; overflow: hidden; white-space: nowrap; border-width: 1px; border-style: solid; border-color: #CCC;">
+        <%= render :partial => 'form', :locals => {:name => 'always', :workflows => @workflows['always']} %>
+      </div>
 
-      <fieldset class="collapsible" style="padding: 0; margin-top: 0.5em;">
-        <legend onclick="toggleFieldset(this);"><%= l(:label_additional_workflow_transitions_for_author) %></legend>
-        <div id="author_workflows" style="margin: 0.5em 0 0.5em 0;">
-          <%= render :partial => 'form', :locals => {:name => 'author', :workflows => @workflows['author']} %>
-        </div>
-      </fieldset>
+      <fieldset class="collapsible collapsed" style="padding: 0; margin-top: 2em; margin-bottom: 1em;">
+        <legend onclick="toggleFieldset(this);toggleDivToFieldset('workflow_author',this.parentNode.className);">
+          <%= l(:label_additional_workflow_transitions_for_author) %>
+        </legend>
+     </fieldset>
+      <div id="workflow_author" style="visibility: hidden; position: fixed; top: 0px; overflow: hidden; white-space: nowrap; border-width: 1px; border-style: solid; border-color: #CCC;">
+        <%= render :partial => 'form', :locals => {:name => 'author', :workflows => @workflows['author']} %>
+      </div>
       <%= javascript_tag "hideFieldset($('#author_workflows'))" unless @workflows['author'].present? %>
 
-      <fieldset class="collapsible" style="padding: 0;">
-        <legend onclick="toggleFieldset(this);"><%= l(:label_additional_workflow_transitions_for_assignee) %></legend>
-        <div id="assignee_workflows" style="margin: 0.5em 0 0.5em 0;">
-      <%= render :partial => 'form', :locals => {:name => 'assignee', :workflows => @workflows['assignee']} %>
-        </div>
-      </fieldset>
-      <%= javascript_tag "hideFieldset($('#assignee_workflows'))" unless @workflows['assignee'].present? %>
+      <fieldset class="collapsible collapsed" style="padding: 0; margin-top: 2em; margin-bottom: 1em;">
+        <legend onclick="toggleFieldset(this);toggleDivToFieldset('workflow_assignee',this.parentNode.className);">
+          <%= l(:label_additional_workflow_transitions_for_assignee) %>
+        </legend>
+       </fieldset>
+      <div id="workflow_assignee" style="visibility: hidden; position: fixed; top: 0px; overflow: hidden; white-space: nowrap; border-width: 1px; border-style: solid; border-color: #CCC;">
+        <%= render :partial => 'form', :locals => {:name => 'assignee', :workflows => @workflows['assignee']} %>
+      </div>
+       <%= javascript_tag "hideFieldset($('#assignee_workflows'))" unless @workflows['assignee'].present? %>
+
+      <script> g_adjust('g_bl_always', 'g_fr_always', 'g_fl_always', 'g_bd_always'); </script>
+      <script> g_adjust('g_bl_author', 'g_fr_author', 'g_fl_author', 'g_bd_author'); </script>
+      <script> g_adjust('g_bl_assignee', 'g_fr_assignee', 'g_fl_assignee', 'g_bd_assignee'); </script>
     </div>
     <%= submit_tag l(:button_save) %>
   <% end %>

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -1,33 +1,59 @@
 <%= title [l(:label_workflow), workflows_edit_path], l(:field_summary) %>
 
 <% if @roles.empty? || @trackers.empty? %>
-<p class="nodata"><%= l(:label_no_data) %></p>
+  <p class="nodata"><%= l(:label_no_data) %></p>
 <% else %>
-<div class="autoscroll">
-<table class="list">
-<thead>
-    <tr>
-    <th></th>
-    <% @roles.each do |role| %>
-    <th>
-        <%= content_tag(role.builtin? ? 'em' : 'span', role.name) %>
-    </th>
-    <% end %>
-    </tr>
-</thead>
-<tbody>
-<% @trackers.each do |tracker| -%>
-<tr class="<%= cycle('odd', 'even') %>">
-  <td class="name"><%= tracker.name %></td>
-  <% @roles.each do |role| -%>
-  <% count = @workflow_counts[[tracker.id, role.id]] || 0 %>
-    <td>
-      <%= link_to((count > 0 ? count : image_tag('false.png')), {:action => 'edit', :role_id => role, :tracker_id => tracker}, :title => l(:button_edit)) %>
-    </td>
-  <% end -%>
-</tr>
-<% end -%>
-</tbody>
-</table>
-</div>
+  <%= stylesheet_link_tag 'divgrid' %>
+  <%= javascript_include_tag 'divgrid' %>
+
+  <div style="position: relative; overflow: hidden; white-space: nowrap; border-width: 1px; border-style: solid; border-color: #CCC;">
+    <!-- Cell 0 -->
+    <div id="g_bl" style="position: absolute; z-index: 2;">
+      <div class="g_c g_h">&nbsp;</div>
+    </div>
+    <!-- Line 0  -->
+    <div id="g_fl" style="position: absolute; left: 0px; right: 13px; overflow: hidden; z-index: 1;">
+      <div style="display: inline-block; margin-right: -4px;">
+        <div class="g_c g_h">&nbsp;</div>
+      </div>
+      <% @roles.each do |role| %>
+        <div style="display: inline-block; margin-right: -4px;">
+          <div class="g_c g_h">
+            <%= role.name %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <!-- Row 0 -->
+    <div id="g_fr" style="position: absolute; left: 0px; top: 0px; bottom: 13px; overflow: hidden; z-index: 1;">
+      <div class="g_c">&nbsp;</div>
+      <% even = false %>
+      <% @trackers.each do |tracker| %>
+        <div class="g_c g_v<%= (even)? " g_e":" g_o" %>">
+          <% even = !even %>
+          <%= tracker.name %>
+        </div>
+      <% end %>
+    </div>
+    <!-- Body -->
+    <div id="g_bd" style="width: 100%; max-height: 80vh; overflow: scroll;" onscroll="g_scroll(this, 'g_fl', 'g_fr')">
+      <div style="display: inline-block; margin-right: -4px;"></div>
+      <% @roles.each do |role| %>
+        <div style="display: inline-block; margin-right: -4px;">
+          <div class="g_c">&nbsp;</div>
+          <% even = false %>
+          <% @trackers.each do |tracker| %>
+            <% count = @workflow_counts[[tracker.id, role.id]] || 0 %>
+            <div class="g_c<%= (even)? " g_e":" g_o" %>" title="<%= "#{tracker} - #{role}" %>">
+              <% even = !even %>
+              <%= link_to((count > 0 ? count : image_tag('false.png')), {:action => 'edit', :role_id => role, :tracker_id => tracker}) %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <script> g_adjust('g_bl', 'g_fr', 'g_fl', 'g_bd'); </script>
+
 <% end %>

--- a/app/views/workflows/permissions.html.erb
+++ b/app/views/workflows/permissions.html.erb
@@ -31,70 +31,138 @@
 <% end %>
 
 <% if @trackers && @roles && @statuses.any? %>
+  <%= stylesheet_link_tag 'divgrid' %>
+  <%= javascript_include_tag 'divgrid' %>
+
+  <script type="text/javascript">
+    function toggleDivToFieldset(divId, fsClass) {
+      console.log(divId + " " + fsClass);
+      if (fsClass.contains("collapsed")) {
+        document.getElementById(divId).style.visibility='hidden';
+        document.getElementById(divId).style.position='fixed';
+      } else {
+        document.getElementById(divId).style.visibility='';
+        document.getElementById(divId).style.position='relative';
+      }
+    }
+  </script>
+
   <%= form_tag({}, :id => 'workflow_form' ) do %>
     <%= @trackers.map {|tracker| hidden_field_tag 'tracker_id[]', tracker.id, :id => nil}.join.html_safe %>
     <%= @roles.map {|role| hidden_field_tag 'role_id[]', role.id, :id => nil}.join.html_safe %>
     <%= hidden_field_tag 'used_statuses_only', params[:used_statuses_only], :id => nil %>
     <div class="autoscroll">
-    <table class="list workflows fields_permissions">
-    <thead>
-      <tr>
-        <th>
-        </th>
-        <th colspan="<%= @statuses.length %>"><%=l(:label_issue_status)%></th>
-      </tr>
-      <tr>
-        <td></td>
-        <% for status in @statuses %>
-        <td style="width:<%= 75 / @statuses.size %>%;">
-          <%= status.name %>
-        </td>
-        <% end %>
-      </tr>
-    </thead>
-    <tbody>
-      <tr class="group open">
-        <td colspan="<%= @statuses.size + 1 %>">
-          <span class="expander" onclick="toggleRowGroup(this);">&nbsp;</span>
+      <fieldset class="collapsible" style="padding: 0; margin-top: 2em; margin-bottom: 1em;">
+        <legend style="padding-left: 0; background: none;">
           <%= l(:field_core_fields) %>
-        </td>
-      </tr>
-      <% @fields.each do |field, name| %>
-      <tr class="<%= cycle("odd", "even") %>">
-        <td class="name">
-          <%= name %> <%= content_tag('span', '*', :class => 'required') if field_required?(field) %>
-        </td>
-        <% for status in @statuses -%>
-        <td class="<%= @permissions[status.id][field].try(:join, ' ') %>">
-          <%= field_permission_tag(@permissions, status, field, @roles) %>
-          <% unless status == @statuses.last %><a href="#" class="repeat-value">&#187;</a><% end %>
-        </td>
-        <% end -%>
-      </tr>
-      <% end %>
+        </legend>
+      </fieldset>
+      <div id='default_fields' style="position: relative; overflow: hidden; white-space: nowrap; border-width: 1px; border-style: solid; border-color: #CCC;">
+        <!-- Cell 0 -->
+        <div id="g_bla" style="position: absolute; z-index: 2;">
+          <div class="g_c g_h">&nbsp;</div>
+        </div>
+        <!-- Line 0  -->
+        <div id="g_fla" style="position: absolute; left: 0px; right: 13px; overflow: hidden; z-index: 1;">
+          <div style="display: inline-block; margin-right: -4px;">
+            <div class="g_c g_h">&nbsp;</div>
+          </div>
+          <% for status in @statuses %>
+            <div style="display: inline-block; margin-right: -4px;">
+              <div class="g_c g_h">
+                <%= status.name %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+        <!-- Row 0 -->
+        <div id="g_fra" style="position: absolute; left: 0px; top: 0px; bottom: 13px; overflow: hidden; z-index: 1;">
+          <div class="g_c">&nbsp;</div>
+          <% even = false %>
+          <% @fields.each do |field, name| %>
+            <div class="g_c g_v<%= (even)? " g_e":" g_o" %>">
+              <% even = !even %>
+              <%= name %> <%= content_tag('span', '*', :class => 'required') if field_required?(field) %>
+            </div>
+          <% end %>
+        </div>
+        <!-- Body -->
+        <div id="g_bda" style="width: 100%; max-height: 80vh; overflow: scroll;" onscroll="g_scroll(this, 'g_fla', 'g_fra')">
+          <div style="display: inline-block; margin-right: -4px;"></div>
+          <% for status in @statuses %>
+            <div style="display: inline-block; margin-right: -4px;">
+              <div class="g_c">&nbsp;</div>
+              <% even = false %>
+              <% @fields.each do |field, name| %>
+                <div class="g_c<%= (even)? " g_e" : " g_o" %> <%= @permissions[status.id][field] %>" title="<%= "#{name} - #{status.name}" %>">
+                  <div style="margin-top: -5px;" >
+                    <% even = !even %>
+                    <%= field_permission_tag(@permissions, status, field, @roles) %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+  
       <% if @custom_fields.any? %>
-        <tr class="group open">
-          <td colspan="<%= @statuses.size + 1 %>">
-            <span class="expander" onclick="toggleRowGroup(this);">&nbsp;</span>
+        <fieldset class="collapsible" style="padding: 0; margin-top: 2em; margin-bottom: 1em;">
+          <legend onclick="toggleFieldset(this);toggleDivToFieldset('personal_fields',this.parentNode.className);">
             <%= l(:label_custom_field_plural) %>
-          </td>
-        </tr>
-        <% @custom_fields.each do |field| %>
-        <tr class="<%= cycle("odd", "even") %>">
-          <td class="name">
-            <%= field.name %> <%= content_tag('span', '*', :class => 'required') if field_required?(field) %>
-          </td>
-          <% for status in @statuses -%>
-          <td class="<%= @permissions[status.id][field.id.to_s] %>">
-            <%= field_permission_tag(@permissions, status, field, @roles) %>
-            <% unless status == @statuses.last %><a href="#" class="repeat-value">&#187;</a><% end %>
-          </td>
-          <% end -%>
-        </tr>
-        <% end %>
-      <% end %>
-    </tbody>
-    </table>
+          </legend>
+        </fieldset>
+        <div id='personal_fields' style="position: relative; overflow: hidden; white-space: nowrap; border-width: 1px; border-style: solid; border-color: #CCC;">
+          <!-- Cell 0 -->
+          <div id="g_blb" style="position: absolute; z-index: 2;">
+            <div class="g_c g_h">&nbsp;</div>
+          </div>
+          <!-- Line 0  -->
+          <div id="g_flb" style="position: absolute; left: 0px; right: 13px; overflow: hidden; z-index: 1;">
+            <div style="display: inline-block; margin-right: -4px;">
+              <div class="g_c g_h">&nbsp;</div>
+            </div>
+            <% for status in @statuses %>
+              <div style="display: inline-block; margin-right: -4px;">
+                <div class="g_c g_h">
+                  <%= status.name %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+          <!-- Row 0 -->
+          <div id="g_frb" style="position: absolute; left: 0px; top: 0px; bottom: 13px; overflow: hidden; z-index: 1;">
+            <div class="g_c">&nbsp;</div>
+            <% even = false %>
+            <% @custom_fields.each do |field| %>
+              <div class="g_c g_v<%= (even)? " g_e":" g_o" %>">
+                <% even = !even %>
+                <%= field.name %> <%= content_tag('span', '*', :class => 'required') if field_required?(field) %>
+              </div>
+            <% end %>
+          </div>
+          <!-- Body -->
+          <div id="g_bdb" style="width: 100%; max-height: 80vh; overflow: scroll;" onscroll="g_scroll(this, 'g_flb', 'g_frb')">
+            <div style="display: inline-block; margin-right: -4px;"></div>
+            <% for status in @statuses %>
+              <div style="display: inline-block; margin-right: -4px;">
+                <div class="g_c">&nbsp;</div>
+                <% even = false %>
+                <% @custom_fields.each do |field| %>
+                  <div class="g_c<%= (even)? " g_e" : " g_o" %> <%= @permissions[status.id][field.id.to_s] %>" title="<%= "#{field.name} - #{status.name}" %>">
+                    <div style="margin-top: -5px;" >
+                      <% even = !even %>
+                      <%= field_permission_tag(@permissions, status, field, @roles) %>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end -%>
+      <script> g_adjust('g_bla', 'g_fra', 'g_fla', 'g_bda'); </script>
+      <script> g_adjust('g_blb', 'g_frb', 'g_flb', 'g_bdb'); </script>
     </div>
     <%= submit_tag l(:button_save) %>
   <% end %>

--- a/public/javascripts/divgrid.js
+++ b/public/javascripts/divgrid.js
@@ -1,0 +1,34 @@
+/* Simple Grid Scripts tables with fixed First Row and Line */
+
+// scrolls first line and row with body
+// div is this
+// row is id of row Ex: g_fr
+// line is id of line Ex: g_fl
+function g_scroll(div, line, row) {
+  document.getElementById(line).style.left = - div.scrollLeft + 'px';
+  document.getElementById(row).style.top = - div.scrollTop + 'px';
+}
+
+// adjusts width of rows
+// bli is the block div
+// fri is the first row div
+// fli is the first line div
+// bdi is the body div
+function g_adjust(bli, fri, fli, bdi) {
+  var frw = document.getElementById(fri).offsetWidth + "px";
+  document.getElementById(bli).style.width = frw
+  var fl = document.getElementById(fli).children;
+  fl[0].style.width = frw
+  var bd = document.getElementById(bdi).children;
+  bd[0].style.width = frw
+
+  for (var i = 1; i < fl.length; ++i) {
+    s1 = fl[i].offsetWidth;
+    s2 = bd[i].offsetWidth;
+    if (s1 > s2) {
+      bd[i].style.width = s1 + "px"
+    } else {
+      fl[i].style.width = s2 + "px"
+    }
+  }
+}

--- a/public/stylesheets/divgrid.css
+++ b/public/stylesheets/divgrid.css
@@ -1,0 +1,36 @@
+/* Simple Grid Styles for tables with fixed First Row and Line */
+
+/* Cell */
+.g_c { height: 1.5em;
+       padding: 6px 12px 6px 12px;
+       border-width: 0px 1px 1px 0px;
+       border-style: solid;
+       border-color: #CCC;
+       text-align: center; }
+
+/* First Line */
+.g_h { background-color: #EEE;
+       /* font-weight: bold; */
+       text-align: center; }
+
+/* First Row */
+.g_v { text-align: left;
+       /* font-weight: bold; */ }
+
+/* Image in Cell */
+.g_i { height: 16px;
+       width: 16px;
+       margin: 0 auto; }
+
+/* Separation Lines */
+.g_s { font-weight: bold;
+       border-right: 0px; }
+
+/* Marked Cell */
+.g_m { background-color: #BFB; }
+
+/* Even Cell */
+.g_e { background-color: #F6F7F8; }
+
+/* Odd Cell */
+.g_o { background-color: #FFFFFF; }


### PR DESCRIPTION
Administration tasks in Redmine have links to reports that show a lot of information on a table. When the table becomes too large or too wide, the web page has to be scrolled right and down, but you lose reference with the first row and first line which shows the row and line names. When the table is not big enough, you can reduce the font size so all the information would fit on your browser, but eventually tables will outgrow this trick and become a hassle to manage.

This patch shows information inside scrollable boxes, retaining the first row and first column, so they are always visible, like in a spreadsheet application.