### PR TITLE
Hide the ordinate overflow (no bottom scrollbar)

### DIFF
--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1,4 +1,4 @@
-html {overflow-y:scroll;}
+html {overflow-y:scroll; overflow-x:hidden;}
 body { font-family: Verdana, sans-serif; font-size: 12px; color:#333; margin: 0; padding: 0; min-width: 900px; }
 
 h1, h2, h3, h4 {font-family: "Trebuchet MS", Verdana, sans-serif;padding: 2px 10px 1px 0px;margin: 0 0 10px 0;}


### PR DESCRIPTION
The layout is mean to be responsive, so it can adapt its ordinate axis without any overflow. However, some little visual glitches can happen, even if there's no visible overflow.

This patch will remove the bottom scrollbar in all cases.