### PR TITLE
Issue destroy : Reassign time issue autocomplete

### DIFF
--- a/app/views/issues/destroy.html.erb
+++ b/app/views/issues/destroy.html.erb
@@ -8,7 +8,8 @@
 <label><%= radio_button_tag 'todo', 'destroy', true %> <%= l(:text_destroy_time_entries) %></label><br />
 <label><%= radio_button_tag 'todo', 'nullify', false %> <%= l(:text_assign_time_entries_to_project) %></label><br />
 <label><%= radio_button_tag 'todo', 'reassign', false, :onchange => 'if (this.checked) { $("#reassign_to_id").focus(); }' %> <%= l(:text_reassign_time_entries) %></label>
-<%= text_field_tag 'reassign_to_id', params[:reassign_to_id], :size => 6, :onfocus => '$("#todo_reassign").attr("checked", true);' %>
+<span id="reassign_to"><%= text_field_tag 'reassign_to_id', params[:reassign_to_id], :size => 7, :onfocus => '$("#todo_reassign").attr("checked", true);' %></span>
+<%= javascript_tag "observeAutocompleteField('reassign_to_id', '#{escape_javascript auto_complete_issues_path(:project_id => @issues.first.project, :scope => Setting.cross_project_subtasks)}')" %>
 </p>
 </div>
 <%= submit_tag l(:button_apply) %>


### PR DESCRIPTION
When deleting an issue, you get a form to propose you where to reassign the time entries. There's now an autocomplete instead of entering the raw issue ID.