### PR TITLE
Fixed quick edit Description when it's still blank and auto focuses on the comment field.

### DIFF
--- a/app/views/issues/_action_menu.html.erb
+++ b/app/views/issues/_action_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="contextual">
-<%= link_to l(:button_edit), edit_issue_path(@issue), :onclick => 'showAndScrollTo("update", "issue_notes"); return false;', :class => 'icon icon-edit', :accesskey => accesskey(:edit) if @issue.editable? %>
+<%= link_to l(:button_edit), edit_issue_path(@issue), :onclick => 'showAndScrollTo("update", "issue_subject"); return false;', :class => 'icon icon-edit', :accesskey => accesskey(:edit) if @issue.editable? %>
 <%= link_to l(:button_log_time), new_issue_time_entry_path(@issue), :class => 'icon icon-time-add' if User.current.allowed_to?(:log_time, @project) %>
 <%= watcher_link(@issue, User.current) %>
 <%= link_to l(:button_copy), project_copy_issue_path(@project, @issue), :class => 'icon icon-copy' if User.current.allowed_to?(:copy_issues, @project) && Issue.allowed_target_projects.any? %>

--- a/app/views/issues/_edit.html.erb
+++ b/app/views/issues/_edit.html.erb
@@ -4,7 +4,7 @@
     <div class="box">
     <% if @issue.attributes_editable? %>
         <fieldset class="tabular"><legend><%= l(:label_change_properties) %></legend>
-        <div id="all_attributes">
+        <div id="all_attributes" autofocus>
         <%= render :partial => 'form', :locals => {:f => f} %>
         </div>
         </fieldset>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -75,9 +75,9 @@ end %>
 <%= call_hook(:view_issues_show_details_bottom, :issue => @issue) %>
 </div>
 
-<% if @issue.description? || @issue.attachments.any? -%>
+<% if @issue.description? || @issue.description = "" || @issue.attachments.any? -%>
 <hr />
-<% if @issue.description? %>
+<% if @issue.description? || @issue.description = "" %>
 <div class="description">
   <div class="contextual">
   <%= link_to l(:button_quote), quoted_issue_path(@issue), :remote => true, :method => 'post', :class => 'icon icon-comment' if @issue.notes_addable? %>


### PR DESCRIPTION
Fixed:
1.Can't quick edit Description when it's still blank
2.Edit auto focuses on the comment field, very confusing