### PR TITLE
Bugfix for redmine.org/issues/26637

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -464,9 +464,9 @@ class Query < ActiveRecord::Base
     json = {}
     available_filters.each do |field, filter|
       options = {:type => filter[:type], :name => filter[:name]}
-      options[:remote] = true if filter.remote
+      options[:remote] = true if filter[:remote]
 
-      if has_filter?(field) || !filter.remote
+      if has_filter?(field) || !filter[:remote]
         options[:values] = filter.values
         if options[:values] && values_for(field)
           missing = Array(values_for(field)).select(&:present?) - options[:values].map(&:last)


### PR DESCRIPTION
The variable filter is of type ActiveSupport::OrderedHash and keys should be accessed with [:key_name_as_symbol] and not as method name.