### PR TITLE
Encryption working incorrectly if string more then 31 symbol

### DIFF
--- a/lib/redmine/ciphering.rb
+++ b/lib/redmine/ciphering.rb
@@ -33,7 +33,7 @@ module Redmine
           c.iv = iv
           e = c.update(text.to_s)
           e << c.final
-          "aes-256-cbc:" + [e, iv].map {|v| Base64.encode64(v).strip}.join('--')
+          "aes-256-cbc:" + [e, iv].map {|v| Base64.strict_encode64(v)}.join('--')
         end
       end
 


### PR DESCRIPTION
encode64 adds \n every 60 symbols, switch to strict_encode64 method, because .strip not working


____________________________________________________________________

**Do not send a pull request to this GitHub repository**.

For more detail, please see [official website] wiki [Contribute].

[official website]: http://www.redmine.org
[Contribute]: http://www.redmine.org/projects/redmine/wiki/Contribute

