### PR TITLE
fix: copyImageFromClipboard in Chrome 92.0.4515.15

### DIFF
--- a/public/javascripts/attachments.js
+++ b/public/javascripts/attachments.js
@@ -278,8 +278,8 @@ function copyImageFromClipboard(e) {
   var items = clipboardData.items
   for (var i = 0 ; i < items.length ; i++) {
     var item = items[i];
-    if (item.type.indexOf("image") != -1) {
-      var blob = item.getAsFile();
+    var blob = item.getAsFile();
+    if (item.type.indexOf("image") != -1 && blob) {
       var date = new Date();
       var filename = 'clipboard-'
         + date.getFullYear()


### PR DESCRIPTION
fix: copyImageFromClipboard  in Chrome August 16, 2021 The Stable channel has been updated to 92.0.4515.15

