### PR TITLE
fix chromium copyImageFromClipboard

### DIFF
--- a/public/javascripts/attachments.js
+++ b/public/javascripts/attachments.js
@@ -278,7 +278,7 @@ function copyImageFromClipboard(e) {
   var items = clipboardData.items
   for (var i = 0 ; i < items.length ; i++) {
     var item = items[i];
-    if (item.type.indexOf("image") != -1) {
+    if ((item.type.indexOf("image") != -1) && (item.kind == 'file'))) {
       var blob = item.getAsFile();
       var date = new Date();
       var filename = 'clipboard-'


### PR DESCRIPTION
Chromium users can have a lot of array values (application/x-qt-image with kind string etc.), we need to get image with kind file only.
i don't think we need to create blob every time for image check
