### PR TITLE
fix: Chromium image from clipboard

### DIFF
--- a/public/javascripts/attachments.js
+++ b/public/javascripts/attachments.js
@@ -278,7 +278,7 @@ function copyImageFromClipboard(e) {
   var items = clipboardData.items
   for (var i = 0 ; i < items.length ; i++) {
     var item = items[i];
-    if (item.type.indexOf("image") != -1) {
+    if ((item.type.indexOf("image") != -1) && (item.kind == 'file')) {
       var blob = item.getAsFile();
       var date = new Date();
       var filename = 'clipboard-'


### PR DESCRIPTION
Chromium displays many values in the array from clipboard, but essentially we only need the "file" type
