### PR TITLE
Unexpected behavior when a user create a project with required custom field 

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -963,6 +963,17 @@ class Project < ActiveRecord::Base
     end
   end
 
+  # Overrides Redmine::Acts::Customizable::InstanceMethods#validate_custom_field_values
+  # so that custom values that are not editable are not validated (eg. a custom field that
+  # is marked as required should not trigger a validation error if the user is not allowed
+  # to edit this field).
+  def validate_custom_field_values
+    user = User.current
+    if new_record? || custom_field_values_changed?
+      editable_custom_field_values(user).each(&:validate_value)
+    end
+  end
+
   # Returns the custom_field_values that can be edited by the given user
   def editable_custom_field_values(user=nil)
     visible_custom_field_values(user)

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -348,6 +348,13 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal parent.children.sort_by(&:name), parent.children.to_a
   end
 
+  def test_validate_custom_field_values_of_project
+    User.current = User.find(3)
+    ProjectCustomField.generate!(:name => 'CustomFieldTest', :field_format => 'int', :is_required => true, :visible => false, :role_ids => [1])
+    p = Project.new(:name => 'Project test', :identifier => 'project-t')
+    assert p.valid?
+  end
+
   def test_set_parent_should_update_issue_fixed_version_associations_when_a_fixed_version_is_moved_out_of_the_hierarchy
     # Parent issue with a hierarchy project's fixed version
     parent_issue = Issue.find(1)


### PR DESCRIPTION
Hello
On a project when a custom field is marked as mandatory but not visible for certain roles, users of these roles can no longer create a project.
