### PR TITLE
Update queries_helper.rb

### DIFF
--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -363,7 +363,7 @@ module QueriesHelper
             session[session_key].nil? ||
             session[session_key][:project_id] != (@project ? @project.id : nil)
       # Give it a name, required to be valid
-      @query = klass.new(:name => "_", :project => @project)
+      @query = klass.new(:name => "_", :project => @project, :visibility => 0)
       @query.build_from_params(params, options[:defaults])
       if use_session
         session[session_key] = {


### PR DESCRIPTION
When SQL Server is used as a database server and executed with db_owner (or db_ddladmin), there is no problem, but when db_datareader or db_datawriter is used, the error “Visibility is not included in the list” error appears on the screen when using db_datareader, db_datawriter.

If db_ddladmin is not set, visibility is nil and this error occurs.

I'm not sure how to fix anything other than this part, but fixing this part anyway will avoid this error.

### SQL Server with db_datareader, db_datawriter.

```ruby
[345, 354] in /var/lib/redmine/app/helpers/queries_helper.rb
   345:     elsif api_request? || params[:set_filter] || !use_session ||
   346:             session[session_key].nil? ||
   347:             session[session_key][:project_id] != (@project ? @project.id : nil)
   348:       # Give it a name, required to be valid
   349:       @query = klass.new(:name => "_", :project => @project)
=> 350:       @query.build_from_params(params, options[:defaults])
   351:       if use_session
   352:         session[session_key] = {
   353:           :project_id => @query.project_id,
   354:           :filters => @query.filters,
(byebug) @query
#<TimeEntryQuery id: nil, project_id: 1, name: "_", filters: {"spent_on"=>{:operator=>"*", :values=>[]}}, user_id: nil, column_names: nil, sort_criteria: [], group_by: nil, type: "TimeEntryQuery", visibility: nil, options: {}>
```

### SQL Server with db_datareader, db_datawriter, db_ddladmin.

```ruby
[345, 354] in /var/lib/redmine/app/helpers/queries_helper.rb
   345:     elsif api_request? || params[:set_filter] || !use_session ||
   346:             session[session_key].nil? ||
   347:             session[session_key][:project_id] != (@project ? @project.id : nil)
   348:       # Give it a name, required to be valid
   349:       @query = klass.new(:name => "_", :project => @project)
=> 350:       @query.build_from_params(params, options[:defaults])
   351:       if use_session
   352:         session[session_key] = {
   353:           :project_id => @query.project_id,
   354:           :filters => @query.filters,
(byebug) @query
#<TimeEntryQuery id: nil, project_id: 1, name: "_", filters: {"spent_on"=>{:operator=>"*", :values=>[]}}, user_id: 0, column_names: nil, sort_criteria: [], group_by: nil, type: "TimeEntryQuery", visibility: 0, options: {}>
```


____________________________________________________________________

Your contributions to Redmine are welcome!

Please **open an issue on the [official website]** instead of sending pull requests.

Since the development of Redmine is not conducted on GitHub but on the [official website] and core developers are not monitoring the GitHub repo, pull requests might not get reviewed.

For more detail about how to contribute, please see the wiki page [Contribute] on the [official website].

[official website]: https://www.redmine.org/
[Contribute]: https://www.redmine.org/projects/redmine/wiki/Contribute
